### PR TITLE
Skip calling `process.exit(1)` - it’s done anyway

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ By default the reporter will
 
 - Make a readable summary of your issues
 - `console.error`-log an error
-- Call `process.exit(1)` / `window.alert(text)`
-- Throw an error
+- `window.alert(text)`
+- Throws an error (will exit the process with a code `1` in node)
 
 Can be overridden by the `reporter`-property
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ By default the reporter will
 
 - Make a readable summary of your issues
 - `console.error`-log an error
-- `window.alert(text)`
+- `window.alert()` with information about the missing envrionment variable if you're in the browser
 - Throws an error (will exit the process with a code `1` in node)
 
 Can be overridden by the `reporter`-property

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -38,9 +38,6 @@ export function defaultReporter<TCleanEnv>(opts: ReporterOpts<TCleanEnv>) {
   const text = defaultReporterText(opts);
   console.error(text);
 
-  if (typeof process !== 'undefined' && process?.exit) {
-    process.exit(1);
-  }
   if (typeof window !== 'undefined' && window?.alert) {
     window.alert(text);
   }

--- a/test/__helpers.ts
+++ b/test/__helpers.ts
@@ -1,14 +1,9 @@
 import { envsafe } from '../src';
 
-let exit: jest.SpyInstance;
 let consoleError: jest.SpyInstance;
 let alert: jest.SpyInstance;
 
 export function mockExitAndConsole() {
-  exit = jest.spyOn(process, 'exit').mockImplementationOnce((() => {
-    // do nothing
-  }) as any);
-
   alert = jest.spyOn(window, 'alert').mockImplementationOnce((() => {
     // do nothing
   }) as any);
@@ -17,10 +12,9 @@ export function mockExitAndConsole() {
     // do nothing
   });
 
-  return { mockExit: exit, mockConsoleError: consoleError };
+  return { mockConsoleError: consoleError };
 }
 export function mockExitAndConsoleWasCalled() {
-  expect(exit).toHaveBeenCalledWith(1);
   expect(alert).toHaveBeenCalledTimes(1);
 
   expect(consoleError).toHaveBeenCalledTimes(1);
@@ -28,7 +22,6 @@ export function mockExitAndConsoleWasCalled() {
   const consoleMessage = consoleError!.mock.calls[0][0];
 
   consoleError.mockClear();
-  exit!.mockClear();
   alert!.mockClear();
 
   return { consoleMessage };

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -80,7 +80,6 @@ test('custom reporter', () => {
   );
 
   expect(mocks.mockConsoleError).not.toHaveBeenCalled();
-  expect(mocks.mockExit).not.toHaveBeenCalled();
 
   expect(reporter.mock.calls).toMatchInlineSnapshot(`
     Array [


### PR DESCRIPTION
Improve DX - skip `process.exit(1)` - it is unnecessarily difficult to handle when running tests both as an author of this lib and a user of it.

Calling `process.exit(1)` is unnecessary - the thrown error is propagated unto an error with code 1 anyway. Try for example `cd examples/playground && yarn && PORT=-1 yarn dev` and you'll see _error Command failed with exit code 1._

Easier to see the error message if it's thrown when using CI.