### PR TITLE
Add `ignoreErrors` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,10 +143,10 @@ By default the reporter will
 
 - Make a readable summary of your issues
 - `console.error`-log an error
-- `window.alert()` with information about the missing envrionment variable if you're in the browser
+- `window.alert()` with information about the missing environment variable if you're in the browser
 - Throws an error (will exit the process with a code `1` in node)
 
-Can be overridden by the `reporter`-property
+Can be disabled with `ignoreErrors` option or customized with the `reporter` option
 
 ```ts
 const env = envsafe(
@@ -154,6 +154,7 @@ const env = envsafe(
     MY_VAR: str(),
   },
   {
+    ignoreErrors: process.env.NODE_ENV === "test",
     reporter({ errors, output, env }) {
       // do stuff
     },

--- a/src/envsafe.ts
+++ b/src/envsafe.ts
@@ -67,6 +67,7 @@ export function envsafe<TCleanEnv>(
     reporter = defaultReporter,
     env = process.env,
     strict = false,
+    ignoreErrors = false,
   }: EnvsafeOpts<TCleanEnv> = {},
 ): Readonly<TCleanEnv> {
   const errors: Errors = {};
@@ -83,7 +84,7 @@ export function envsafe<TCleanEnv>(
   }
 
   if (Object.keys(errors).length) {
-    reporter({ errors, output, env });
+    reporter({ errors, output, env, ignoreErrors });
   }
 
   return strict ? freezeObject(output, env) : output;

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -38,9 +38,11 @@ export function defaultReporter<TCleanEnv>(opts: ReporterOpts<TCleanEnv>) {
   const text = defaultReporterText(opts);
   console.error(text);
 
-  if (typeof window !== 'undefined' && window?.alert) {
-    window.alert(text);
-  }
+  if (opts.ignoreErrors !== true) {
+    if (typeof window !== 'undefined' && window?.alert) {
+      window.alert(text);
+    }
 
-  throw new TypeError(text);
+    throw new TypeError(text);
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,7 +45,15 @@ export type Environment = Record<string, string | undefined>;
 
 export type Errors = Record<string, Error>;
 
-export type ReporterOpts<TCleanEnv> = {
+type IgnoreErrorsOption = {
+  /**
+   * Skip throwing errors when invalid configuration is found, useful in tests where not all runtime configuration is necessary
+   * @default false
+   */
+  ignoreErrors?: boolean;
+};
+
+export type ReporterOpts<TCleanEnv> = IgnoreErrorsOption & {
   env: Environment;
   output: Partial<TCleanEnv>;
   errors: Errors;
@@ -53,7 +61,7 @@ export type ReporterOpts<TCleanEnv> = {
 
 export type ReporterFn<TCleanEnv> = (opts: ReporterOpts<TCleanEnv>) => void;
 
-export type EnvsafeOpts<TCleanEnv> = {
+export type EnvsafeOpts<TCleanEnv> = IgnoreErrorsOption & {
   /**
    * Override the built-in reporter
    * @default `defaultReporter`

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -91,6 +91,7 @@ test('custom reporter', () => {
           "errors": Object {
             "foo": [TypeError: Expected 'not bar' to be 'bar'],
           },
+          "ignoreErrors": false,
           "output": Object {},
         },
       ],


### PR DESCRIPTION
Adds an option to envsafe (and the reporter) to not report errors if they are encountered.

This is useful if you have certain conditions where you don't want to report errors - like in test environments where you're mocking a lot of stuff.

This was previously possible through using an empty function as the reporter, but this is cleaner shows that it's possible in a clearer way. 😄 