### PR TITLE
feat: Add `inputOnly` option for exclusive input utilization

### DIFF
--- a/src/envsafe.ts
+++ b/src/envsafe.ts
@@ -33,7 +33,9 @@ function getValueOrThrow<TValue>({
 
   let input: string | TValue | undefined = isSet(validator.input)
     ? validator.input
-    : env[key];
+    : !validator.inputOnly
+    ? env[key]
+    : undefined;
 
   if (usingDevDefault && !isSet(input) && isSet(validator.devDefault)) {
     input = validator.devDefault;
@@ -67,13 +69,17 @@ export function envsafe<TCleanEnv>(
     reporter = defaultReporter,
     env = process.env,
     strict = false,
+    inputOnly = false,
   }: EnvsafeOpts<TCleanEnv> = {},
 ): Readonly<TCleanEnv> {
   const errors: Errors = {};
   const output = {} as TCleanEnv;
 
   for (const key in validators) {
-    const validator = validators[key];
+    const validator = {
+      inputOnly,
+      ...validators[key],
+    };
     try {
       const resolved = getValueOrThrow({ env, validator, key });
       output[key] = resolved;

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,10 @@ export interface Spec<TValue> {
    * Can be useful on the front-end when webpack makes the vars disappear
    */
   input?: string | undefined;
+  /**
+   * Determine whether to use only the `input` values and avoid runtime environment variable reference.
+   */
+  inputOnly?: boolean;
 }
 
 export interface ValidatorSpec<TValue> extends Spec<TValue> {
@@ -69,6 +73,11 @@ export type EnvsafeOpts<TCleanEnv> = {
    * @default false
    */
   strict?: boolean;
+  /**
+   * Determine whether to use only the `input` values and avoid runtime environment variable reference.
+   * @default false
+   */
+  inputOnly?: boolean;
 };
 
 export type Validators<TCleanEnv> = {

--- a/test/inputOnly.test.ts
+++ b/test/inputOnly.test.ts
@@ -39,7 +39,7 @@ test('input with undefined', () => {
   });
 });
 
-test('input with inputOnly option', () => {
+test('input value is undefined and inputOnly is true', () => {
   mockAlertAndConsole();
 
   expect(() =>

--- a/test/inputOnly.test.ts
+++ b/test/inputOnly.test.ts
@@ -1,0 +1,68 @@
+import { envsafe, str } from '../src';
+import { expectExitAndAlertWasCalled, mockAlertAndConsole } from './__helpers';
+
+test('input with valid value', () => {
+  expect(
+    envsafe(
+      {
+        str: str({
+          input: 'foo',
+        }),
+      },
+      {
+        env: {
+          str: 'bar',
+        },
+      },
+    ),
+  ).toEqual({
+    str: 'foo',
+  });
+});
+
+test('input with undefined', () => {
+  expect(
+    envsafe(
+      {
+        str: str({
+          input: undefined,
+        }),
+      },
+      {
+        env: {
+          str: 'bar',
+        },
+      },
+    ),
+  ).toEqual({
+    str: 'bar',
+  });
+});
+
+test('input with inputOnly option', () => {
+  mockAlertAndConsole();
+
+  expect(() =>
+    envsafe(
+      {
+        str: str({
+          input: undefined,
+          inputOnly: true,
+        }),
+      },
+      {
+        env: {
+          str: 'bar',
+        },
+      },
+    ),
+  ).toThrowError();
+
+  const { consoleMessage } = expectExitAndAlertWasCalled();
+  expect(consoleMessage).toMatchInlineSnapshot(`
+    "========================================
+    💨 Missing environment variables:
+        str: Missing value or empty string
+    ========================================"
+  `);
+});

--- a/test/inputOnly.test.ts
+++ b/test/inputOnly.test.ts
@@ -66,3 +66,31 @@ test('input value is undefined and inputOnly is true', () => {
     ========================================"
   `);
 });
+
+test('input value is undefined and inputOnly (global option) is true', () => {
+  mockAlertAndConsole();
+
+  expect(() =>
+    envsafe(
+      {
+        str: str({
+          input: undefined,
+        }),
+      },
+      {
+        env: {
+          str: 'bar',
+        },
+        inputOnly: true,
+      },
+    ),
+  ).toThrowError();
+
+  const { consoleMessage } = expectExitAndAlertWasCalled();
+  expect(consoleMessage).toMatchInlineSnapshot(`
+    "========================================
+    💨 Missing environment variables:
+        str: Missing value or empty string
+    ========================================"
+  `);
+});


### PR DESCRIPTION
This commit adds the `inputOnly` option to `EnvsafeOpts`, enabling exclusive use of input values and enhancing typo detection. When `inputOnly` is set to `true`, `envsafe` disregards runtime environment variable references and solely relies on the provided input values.

This improvement ensures better reliability and prevents unnoticed typos in environment variable references that were previously masked by fallback values.

---
I strongly agree with the opinion that there could be a better name than "inputOnly" for the introduced option.


Closes #146 
